### PR TITLE
Fix Multicast with VideoXpert Enterprise

### DIFF
--- a/Source/RtspRedirect.cs
+++ b/Source/RtspRedirect.cs
@@ -26,7 +26,7 @@ namespace RTSPRedirect
             }
 
             // Check if the RTSP URL is for a multicast stream
-            var isMulticast = urlFromDataSource.Contains("multicast=true");
+            var isMulticast = urlFromDataSource.Contains("multicast=true") || urlFromDataSource.Contains("transport_type=UDP_MULTICAST");
 
             // Create the communication socket
             var socket = CreateSocket(urlFromDataSource, ref errorMessage);


### PR DESCRIPTION
https://github.com/pelcointegrations/RTSP-Redirect-Example/blob/db4464e5e6db7eb243730fee0a47f67afe4bfb28/Source/RtspRedirect.cs#L29

RTSP/1.0 461 Unsupported transport
Content-Type: application/text
content-length: 104
CSeq: 7
Server: /10.107.1.65:554
Date: Tue, 26 Feb 2019 08:36:12 GMT
 
SETUP request has unexpected transport type in header. Expecting [UDP_MULTICAST], but got [UDP_UNICAST].